### PR TITLE
Add prlimit command to change ulimit of 3proxy Service

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -111,6 +111,7 @@ cat >>/etc/rc.local <<EOF
 bash ${WORKDIR}/boot_iptables.sh
 bash ${WORKDIR}/boot_ifconfig.sh
 ulimit -n 65536
+prlimit --pid=65535 --nofile=65535
 service 3proxy start
 EOF
 
@@ -119,3 +120,5 @@ bash /etc/rc.local
 gen_proxy_file_for_user
 
 upload_proxy
+
+prlimit --pid=65535 --nofile=65535


### PR DESCRIPTION
Added in prlimit --pid=65535 --nofile=65535 line to increase the ulimit of the 3proxy process.

Found this command [here.](https://superuser.com/questions/1289345/why-doesnt-ulimit-n-work-when-called-inside-a-script)

Edit: I messed up, the PID is not 65535 but varies as the system creates and removes 3proxy processes. This does not seem to be a permanent working solution.